### PR TITLE
Fixed failing test with tolerance (shows there was no real problem).

### DIFF
--- a/lib/iris/tests/results/analysis/interpolation/linear/real_circular_2dslice.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/real_circular_2dslice.cml
@@ -137,6 +137,6 @@
         <coord interval="1 hour" name="time"/>
       </cellMethod>
     </cellMethods>
-    <data byteorder="little" checksum="0x55dde6eb" dtype="float32" shape="(38, 145)"/>
+    <data byteorder="little" dtype="float32" shape="(38, 145)" state="loaded"/>
   </cube>
 </cubes>

--- a/lib/iris/tests/test_interpolation.py
+++ b/lib/iris/tests/test_interpolation.py
@@ -555,18 +555,18 @@ class TestNearestLinearInterpolRealData(tests.IrisTest):
              self.cube.data[..., -1][..., None]], axis=2), axis=2)
 
         lon_coord = self.cube.coord('longitude').points
-        expected = self.cube.data[..., 0] + ((self.cube.data[..., -1] -
-                                              self.cube.data[..., 0]) *
-                                             (((360 - 359.8) - lon_coord[0]) /
-                                               ((360 - lon_coord[-1]) - lon_coord[0])))
-        self.assertArrayEqual(res.data, expected)
+        expected = (self.cube.data[..., 0] +
+                       ((self.cube.data[..., -1] - self.cube.data[..., 0]) *
+                           (((360 - 359.8) - lon_coord[0]) /
+                            ((360 - lon_coord[-1]) - lon_coord[0]))))
+        self.assertArrayAllClose(r.data, expected, rtol=2.0e-7)
 
         # check that the values returned by lon 0 & 360 are the same...
         r1 = iris.analysis.interpolate.linear(self.cube, [('longitude', 360)])
         r2 = iris.analysis.interpolate.linear(self.cube, [('longitude', 0)])
         np.testing.assert_array_equal(r1.data, r2.data)
 
-        self.assertCML(res, ('analysis', 'interpolation', 'linear', 'real_circular_2dslice.cml'), checksum=False)
+        self.assertCML(r, ('analysis', 'interpolation', 'linear', 'real_circular_2dslice.cml'), checksum=False)
 
 
 @tests.skip_data


### PR DESCRIPTION
Checked the numbers with code like : https://gist.github.com/pp-mo/9979539
Results:

```
    values:     min=     243.268,     max=     1453.17,    mean=     409.069,  median=     319.299
     diffs:     min= -0.00012207,     max=  0.00012207,    mean=-2.16005e-07,  median=           0
 abs-diffs:     min=           0,     max=  0.00012207,    mean= 9.30482e-06,  median=           0
 rel-diffs:     min=           0,     max= 1.01501e-07,    mean= 6.86106e-09,  median=           0
```

So, no problem really -- the absolute and relative differences are really very small.
