### PR TITLE
Restore interp cml

### DIFF
--- a/lib/iris/tests/results/analysis/interpolation/linear/real_circular_2dslice.cml
+++ b/lib/iris/tests/results/analysis/interpolation/linear/real_circular_2dslice.cml
@@ -137,6 +137,6 @@
         <coord interval="1 hour" name="time"/>
       </cellMethod>
     </cellMethods>
-    <data byteorder="little" checksum="0x55dde6eb" dtype="float32" shape="(38, 145)"/>
+    <data byteorder="little" dtype="float32" shape="(38, 145)" state="loaded"/>
   </cube>
 </cubes>


### PR DESCRIPTION
This fixes a current problem with the testing.
For some reason, this CML file got deleted instead of updated in an earlier commit, now on cp/interp_refactor : https://github.com/cpelley/iris/commit/85ea6d53289d28c25d80c70bd52158220c50ffe2

These 2 commits restore the file as it was, then update to fix the test (difference is v. small, apparently due to test now being checksum=False)
