### PR TITLE
Update what Biggus conda uses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ install:
   # ---------------------------------
   - conda config --add channels scitools
   - conda install --quiet --file conda-requirements.txt
-  - conda install --quiet -c scitools/channel/dev biggus=0.7.0.post.180 --no-deps --yes
 
   - PREFIX=$HOME/miniconda/envs/$ENV_NAME
 

--- a/INSTALL
+++ b/INSTALL
@@ -53,7 +53,7 @@ python 2.7 or later (http://www.python.org/)
 numpy 1.6 or later (http://numpy.scipy.org/)
     Python package for scientific computing including a powerful N-dimensional array object.
 
-biggus 0.7 or later (https://github.com/SciTools/biggus)
+biggus 0.8 or later (https://github.com/SciTools/biggus)
     Virtual large arrays and lazy evaluation.
 
 scipy 0.10 or later (http://www.scipy.org/)


### PR DESCRIPTION
I removed the line since conda-requirements.txt is already installing biggus 0.8.0